### PR TITLE
conf의 Server객체를  Socket클래스가 가지도록 수정

### DIFF
--- a/app/main.cpp
+++ b/app/main.cpp
@@ -14,7 +14,7 @@ int main(int argc, char **argv) {
 	}
 
 	if (argc == 1)
-		config = "./conf/default.config";
+		config = "./conf/example.conf";
 	else
 		config = argv[1];
 	try {
@@ -25,7 +25,7 @@ int main(int argc, char **argv) {
 		webserv.SetupServer(server_blocks);
 		webserv.StartServer();
 	} catch (const std::exception &e) {
-		std::cerr << e.what() << '\n';
+		std::cerr << e.what() << std::endl;
 	}
 	return 0;
 }

--- a/includes/core/client_socket.hpp
+++ b/includes/core/client_socket.hpp
@@ -8,6 +8,7 @@
 #include <vector>
 #include <ctime>
 
+#include "server.hpp"
 #include "socket.hpp"
 #include "request_parser.hpp"
 #include "response_message.hpp"
@@ -25,7 +26,7 @@ class ClientSocket : public Socket {
 		RESPONSE
 	};
 
-	ClientSocket(int sock_d);
+	ClientSocket(int sock_d, const Server & server_info);
 	~ClientSocket();
 
 	const State &GetPrevState() const;

--- a/includes/core/server_socket.hpp
+++ b/includes/core/server_socket.hpp
@@ -6,12 +6,13 @@
 #include <cstdlib>
 #include <iostream>
 
-#include "socket.hpp"
+#include "socket.hpp" // core/socket.hpp
+#include "server.hpp" // conf/server.hpp
 
 class ServerSocket : public Socket {
    public:
 	static const int BACK_LOG_QUEUE;
-	ServerSocket(const std::string &host, const std::string &port);
+	explicit ServerSocket(const Server & s);
 	~ServerSocket();
 
 	void ListenSocket();

--- a/includes/core/socket.hpp
+++ b/includes/core/socket.hpp
@@ -4,11 +4,12 @@
 #include <netinet/in.h>
 #include <sys/socket.h>
 #include <iostream>
+#include "server.hpp"
 
 class Socket {
    public:
-	Socket();
-	virtual ~Socket();
+	explicit Socket(const Server & s);
+	virtual ~Socket() = 0;
 
 	enum {
 		CLIENT_TYPE,
@@ -18,7 +19,10 @@ class Socket {
 	const int &GetType() const;
 	const int &GetSocketDescriptor() const;
 	void Close() const;
+	const Server &GetServerInfo() const;
+
    protected:
+	const Server & server_info_;
 	int type_;
 	int sock_d_;
 	struct sockaddr_in address_;

--- a/includes/request/request_message.hpp
+++ b/includes/request/request_message.hpp
@@ -18,7 +18,7 @@ class RequestMessage {
    public:
 	typedef std::map<std::string, std::string> headers_type;
 
-	RequestMessage();
+	explicit RequestMessage(int c_max_size);
 	~RequestMessage();
 
 	const std::string &GetMethod() const;
@@ -42,6 +42,7 @@ class RequestMessage {
 	class RequestChunkedParser;
 
    private:
+	const int client_max_body_size_;
 	std::string method_;
 	std::string uri_;
 	std::string http_version_;

--- a/sources/core/client_socket.cpp
+++ b/sources/core/client_socket.cpp
@@ -4,8 +4,10 @@
 
 const int ClientSocket::BUFFER_SIZE = 1024;
 
-ClientSocket::ClientSocket(int sock_d)
-	: parser_(request_),
+ClientSocket::ClientSocket(int sock_d, const Server & s)
+	: Socket(s),
+	  request_(s.GetClientMaxBodySize()),
+	  parser_(request_),
 	  response_(request_),
 	  prev_state_(INIT),
 	  state_(REQUEST) {

--- a/sources/core/server_socket.cpp
+++ b/sources/core/server_socket.cpp
@@ -7,9 +7,9 @@
 
 const int ServerSocket::BACK_LOG_QUEUE = 5;
 
-ServerSocket::ServerSocket(const std::string &host, const std::string &port) {
+ServerSocket::ServerSocket(const Server & s) : Socket(s) {
 	type_ = Socket::SERVER_TYPE;
-	CreateSocket(host, port);
+	CreateSocket(server_info_.GetHost(), server_info_.GetPort());
 	if (sock_d_ > 0) {
 		ListenSocket();
 	}

--- a/sources/core/socket.cpp
+++ b/sources/core/socket.cpp
@@ -3,7 +3,7 @@
 #include <arpa/inet.h>
 #include <unistd.h>
 
-Socket::Socket() {}
+Socket::Socket(const Server & s) : server_info_(s) {}
 
 Socket::~Socket() {}
 
@@ -16,6 +16,7 @@ void Socket::Close() const {
 		perror("close: ");
 	}
 }
+const Server &Socket::GetServerInfo() const { return server_info_; }
 
 std::ostream &operator<<(std::ostream &out, const Socket *socket) {
 	int fd = socket->GetSocketDescriptor();

--- a/sources/core/webserv.cpp
+++ b/sources/core/webserv.cpp
@@ -5,27 +5,18 @@ Webserv::Webserv() {}
 Webserv::~Webserv() {}
 
 void Webserv::SetupServer(const ConfigParser::servers_type &servers) {
-	std::vector<std::string> port;
-	port.push_back("8181");
-	port.push_back("8282");
-	port.push_back("8383");
-
-	// collect kevents
-	for (size_t i = 0; i < port.size(); ++i) {
-		ServerSocket *server = new ServerSocket("localhost", port[i]);
-		server->ListenSocket();
-		AddServerKevent(server);
-	}
+	// ConfigParser::servers_type은 현재 vector인데, map으로 변경 될 예정
 
 	for (size_t i = 0; i < servers.size(); ++i) {
-		Server item = servers[i];
-		ServerSocket *server = new ServerSocket(item.GetHost(), item.GetPort());
+		const Server & single_server_info = servers[i];
+		ServerSocket *server = new ServerSocket(single_server_info);
+		server->ListenSocket();
 		AddServerKevent(server);
 	}
 }
 
 void Webserv::AddServerKevent(ServerSocket *server) {
-	kq_handler_.AddReadEvent(server->GetSocketDescriptor(), server);
+	kq_handler_.AddReadEvent(server->GetSocketDescriptor(), reinterpret_cast<void *>(server));
 }
 
 void Webserv::DeleteClientPrevKevent(ClientSocket *client) {
@@ -126,7 +117,7 @@ void Webserv::HandleClientSocketEvent(Socket *socket, struct kevent event) {
 
 void Webserv::HandleServerSocketEvent(Socket *socket) {
 	ServerSocket *server = dynamic_cast<ServerSocket *>(socket);
-	ClientSocket *client = new ClientSocket(server->AcceptClient());
+	ClientSocket *client = new ClientSocket(server->AcceptClient(), server->GetServerInfo());
 	AddClientKevent(client);
 	std::cout << "Got connection " << client->GetSocketDescriptor()
 			  << std::endl;

--- a/sources/request/request_message.cpp
+++ b/sources/request/request_message.cpp
@@ -4,8 +4,8 @@
 #include <locale>
 #include <sstream>
 
-RequestMessage::RequestMessage()
-	: content_size_(-1), is_chunked_(false), keep_alive_(true) {}
+RequestMessage::RequestMessage(int client_max_body_size)
+	: client_max_body_size_(client_max_body_size), content_size_(-1), is_chunked_(false), keep_alive_(true) {}
 
 RequestMessage::~RequestMessage() {}
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,7 +12,6 @@ add_executable(webserv_test
         get_method_test.cpp
         main.cpp
         post_method_test.cpp
-        socket_test.cpp
         status_line_test.cpp
         header_test.cpp
         response_message_test.cpp


### PR DESCRIPTION
- Socket클래스의 추상클래스화
- Socket 파생 객체(ServerSocket, ClientSocket)가 Server객체의 참조를 가지도록 변경
- Client소켓의 RequestMessage객체가 Server객체가 가지는 정보의 일부를 가지도록 변경