### PR TITLE
Space Tab으로 변경 및 ServerSocket생성자 수정

### DIFF
--- a/includes/core/client_socket.hpp
+++ b/includes/core/client_socket.hpp
@@ -13,7 +13,6 @@
 
 class ClientSocket : public Socket {
    public:
-	typedef ServerSocket::server_infos_type server_infos_type;
 
 	explicit ClientSocket(const int &sock_d,
 						  const server_infos_type &server_infos);
@@ -32,7 +31,6 @@ class ClientSocket : public Socket {
 	void FindLocationWithUri(const std::string &uri);
 
    private:
-	const server_infos_type &server_infos_;
 	server_infos_type::const_iterator server_info_it_;
 	int location_index_;
 };

--- a/includes/core/event_handler.hpp
+++ b/includes/core/event_handler.hpp
@@ -6,17 +6,17 @@
 
 class EventHandler {
 public:
-    static const int RESPONSE_END = 0;
-    static const int CLOSE = 1;
-    static const int KEEP_ALIVE = 2;
-    static const int ERROR = 3;
-    static const int HAS_MORE = 4;
+	static const int RESPONSE_END = 0;
+	static const int CLOSE = 1;
+	static const int KEEP_ALIVE = 2;
+	static const int ERROR = 3;
+	static const int HAS_MORE = 4;
 
-    static int HandleListenEvent(ServerSocket server_socket);
+	static int HandleListenEvent(ServerSocket server_socket);
 
-    static int HandleRequestEvent(ClientSocket &client_socket,
-                                  Udata *user_data);
+	static int HandleRequestEvent(ClientSocket &client_socket,
+									Udata *user_data);
 
-    static int HandleResponseEvent(const ClientSocket &client_socket,
-                                   Udata *user_data);
+	static int HandleResponseEvent(const ClientSocket &client_socket,
+									Udata *user_data);
 };

--- a/includes/core/server_socket.hpp
+++ b/includes/core/server_socket.hpp
@@ -12,11 +12,9 @@
 
 class ServerSocket : public Socket {
    public:
-	typedef ConfigParser::server_infos_type server_infos_type;
 	static const int BACK_LOG_QUEUE;
 
-	explicit ServerSocket(const std::string &addr,
-						  const server_infos_type &server_infos);
+	ServerSocket(const std::string &addr, const server_infos_type &server_infos);
 	~ServerSocket();
 
 	const server_infos_type &GetServerInfos() const;
@@ -25,7 +23,6 @@ class ServerSocket : public Socket {
 	int AcceptClient();
 
    private:
-	const server_infos_type &server_infos_;
 
 	void CreateSocket(const std::string &host, const std::string &port);
 	struct addrinfo *GetAddrInfos(const std::string &host,

--- a/includes/core/socket.hpp
+++ b/includes/core/socket.hpp
@@ -7,13 +7,15 @@
 #include <iostream>
 #include <vector>
 
+#include "config_parser.hpp"
 #include "server_info.hpp"
 
 class Socket {
    public:
+	typedef ConfigParser::server_infos_type server_infos_type;
 	enum { CLIENT_TYPE, SERVER_TYPE };
 
-	explicit Socket(int sock_d);
+	Socket(int sock_d, const server_infos_type &server_infos);
 	virtual ~Socket() = 0;
 
 	const int &GetSocketDescriptor() const;
@@ -21,6 +23,7 @@ class Socket {
 	void Close() const;
 
    protected:
+	const server_infos_type &server_infos_;
 	int sock_d_;
 	struct sockaddr_in address_;
 };

--- a/includes/core/udata.h
+++ b/includes/core/udata.h
@@ -11,19 +11,19 @@
 
 class Udata {
    public:
-    enum State {
-        LISTEN,
-        RECV_REQUEST,
-        READ_FILE,
-        WRITE_TO_PIPE,
-        READ_FROM_PIPE,
-        SEND_RESPONSE,
-        CLOSE
-    };
+	enum State {
+		LISTEN,
+		RECV_REQUEST,
+		READ_FILE,
+		WRITE_TO_PIPE,
+		READ_FROM_PIPE,
+		SEND_RESPONSE,
+		CLOSE
+	};
 	explicit Udata(int state, int sock_d);
 	virtual ~Udata();
 
-    const int &GetState() const;
+	const int &GetState() const;
 	void ChangeState(const int &state);
 	void Reset();
 

--- a/includes/core/webserv.hpp
+++ b/includes/core/webserv.hpp
@@ -12,37 +12,37 @@
 
 class Webserv {
 public:
-    typedef ConfigParser::server_configs_type server_configs_type;
-    typedef std::map<int, ServerSocket> servers_type;
-    typedef std::map<int, ClientSocket> clients_type;
+	typedef ConfigParser::server_configs_type server_configs_type;
+	typedef std::map<int, ServerSocket> servers_type;
+	typedef std::map<int, ClientSocket> clients_type;
 
-    explicit Webserv(const server_configs_type &server_configs);
+	explicit Webserv(const server_configs_type &server_configs);
 
-    ~Webserv();
+	~Webserv();
 
-    void StartServer();
+	void StartServer();
 
 private:
-    servers_type servers_;
-    clients_type clients_;
-    KqueueHandler kq_handler_;
+	servers_type servers_;
+	clients_type clients_;
+	KqueueHandler kq_handler_;
 
-    void HandleEvent(struct kevent &event);
+	void HandleEvent(struct kevent &event);
 
-    void HandleListenEvent(const ServerSocket &server_socket);
+	void HandleListenEvent(const ServerSocket &server_socket);
 
 
-    void HandleReceiveRequestEvent(ClientSocket &client_socket,
-                                   Udata *user_data);
+	void HandleReceiveRequestEvent(ClientSocket &client_socket,
+									Udata *user_data);
 
-    void HandleReadFile(Udata *user_data, int fd);
+	void HandleReadFile(Udata *user_data, int fd);
 
-    void HandleSendResponseEvent(const ClientSocket &client_socket,
-                                 Udata *user_data);
+	void HandleSendResponseEvent(const ClientSocket &client_socket,
+									Udata *user_data);
 
-    ServerSocket &FindServerSocket(const int &fd);
+	ServerSocket &FindServerSocket(const int &fd);
 
-    ClientSocket &FindClientSocket(const int &fd);
+	ClientSocket &FindClientSocket(const int &fd);
 };
 
 #endif

--- a/includes/exception/http_exception.hpp
+++ b/includes/exception/http_exception.hpp
@@ -8,7 +8,7 @@ class HttpException : public std::exception {
 	HttpException(int status_code);
 	const char *what() const throw();
 
-    int GetStatusCode() const;
+	int GetStatusCode() const;
 
 private:
 	int status_code_;

--- a/sources/core/client_socket.cpp
+++ b/sources/core/client_socket.cpp
@@ -7,8 +7,7 @@
 
 ClientSocket::ClientSocket(const int &sock_d,
 						   const server_infos_type &server_infos)
-	: Socket(sock_d),
-	  server_infos_(server_infos),
+	: Socket(sock_d, server_infos),
 	  server_info_it_(server_infos.cbegin()),
 	  location_index_(-1) {}
 

--- a/sources/core/fd_handler.cpp
+++ b/sources/core/fd_handler.cpp
@@ -9,22 +9,22 @@
 #include "udata.h"
 
 int OpenFile(const Udata &user_data) {
-    std::vector<std::string> resolved_uri = user_data.request_message_.GetResolvedUri();
-    int fd;
+	std::vector<std::string> resolved_uri = user_data.request_message_.GetResolvedUri();
+	int fd;
 
-    for (size_t i = 0; i < resolved_uri.size(); i++) {
-        fd = open(resolved_uri.at(i).c_str(), O_RDONLY);
-        if (fd < 0) {
-            if (errno == ENOENT && i == resolved_uri.size() - 1) {
-                std::perror("open: NOT_FOUND");
-                throw (HTTP_EXCEPTION(NOT_FOUND));
-            }
-            if (errno == EACCES) {
-                std::perror("open: FORBIDDEN");
-                throw (HTTP_EXCEPTION(FORBIDDEN));
-            }
-        }
-    }
-    return fd;
+	for (size_t i = 0; i < resolved_uri.size(); i++) {
+		fd = open(resolved_uri.at(i).c_str(), O_RDONLY);
+		if (fd < 0) {
+			if (errno == ENOENT && i == resolved_uri.size() - 1) {
+				std::perror("open: NOT_FOUND");
+				throw (HTTP_EXCEPTION(NOT_FOUND));
+			}
+			if (errno == EACCES) {
+				std::perror("open: FORBIDDEN");
+				throw (HTTP_EXCEPTION(FORBIDDEN));
+			}
+		}
+	}
+	return fd;
 }
 

--- a/sources/core/resolve_uri.cpp
+++ b/sources/core/resolve_uri.cpp
@@ -9,47 +9,47 @@
 #include <iostream>
 
 void Resolve_URI(const ClientSocket &client, const RequestMessage &request, Udata *user_data) {
-    std::string uri = request.GetUri();
-    ServerInfo server_infos = client.GetServerInfo();
-    int location_idx = client.GetLocationIndex();
-    std::string root;
-    std::string default_root("/var/www");
-    std::string base_uri;
-    std::vector<std::string> index;
-    std::vector<std::string> resolved_uri;
-    LocationInfo location_info;
+	std::string uri = request.GetUri();
+	ServerInfo server_infos = client.GetServerInfo();
+	int location_idx = client.GetLocationIndex();
+	std::string root;
+	std::string default_root("/var/www");
+	std::string base_uri;
+	std::vector<std::string> index;
+	std::vector<std::string> resolved_uri;
+	LocationInfo location_info;
 
-    if (server_infos.IsRoot()) { // root 존재
-        base_uri.append(server_infos.GetRoot());
-    } else // root 존재 안함
-        base_uri.append(default_root);
-    if (location_idx == -1) {
-        if (server_infos.IsIndex() && uri.compare("/") == 0) { // index 존재 하는 경우 and uri '/'
-            index = server_infos.GetIndex();
-            for (std::vector<std::string>::iterator it = index.begin(); it != index.end(); ++it) {
-                resolved_uri.push_back(base_uri + '/' + *it);
-            }
-        } else { // index 존재 하지 않는 경우
-            base_uri.append(uri);
-            resolved_uri.push_back(base_uri);
-        }
-    } else {
-        location_info = server_infos.GetLocations().at(location_idx);
-        if (location_info.IsRoot()) { // root 존재
-            base_uri.clear();
-            base_uri.append(location_info.GetRoot());
-        }
-        if (location_info.IsIndex() &&
-            uri.compare(location_info.GetPath()) == 0) { // index 존재 하는 경우 and uri '/location'
-            base_uri.append(location_info.GetPath());
-            index = location_info.GetIndex();
-            for (std::vector<std::string>::iterator it = index.begin(); it != index.end(); ++it) {
-                resolved_uri.push_back(base_uri + '/' + *it);
-            }
-        } else {
-            base_uri.append(uri);
-            resolved_uri.push_back(base_uri);
-        }
-    }
-    user_data->request_message_.SetResolvedUri(resolved_uri);
+	if (server_infos.IsRoot()) { // root 존재
+		base_uri.append(server_infos.GetRoot());
+	} else // root 존재 안함
+		base_uri.append(default_root);
+	if (location_idx == -1) {
+		if (server_infos.IsIndex() && uri.compare("/") == 0) { // index 존재 하는 경우 and uri '/'
+			index = server_infos.GetIndex();
+			for (std::vector<std::string>::iterator it = index.begin(); it != index.end(); ++it) {
+				resolved_uri.push_back(base_uri + '/' + *it);
+			}
+		} else { // index 존재 하지 않는 경우
+			base_uri.append(uri);
+			resolved_uri.push_back(base_uri);
+		}
+	} else {
+		location_info = server_infos.GetLocations().at(location_idx);
+		if (location_info.IsRoot()) { // root 존재
+			base_uri.clear();
+			base_uri.append(location_info.GetRoot());
+		}
+		if (location_info.IsIndex() &&
+			uri.compare(location_info.GetPath()) == 0) { // index 존재 하는 경우 and uri '/location'
+			base_uri.append(location_info.GetPath());
+			index = location_info.GetIndex();
+			for (std::vector<std::string>::iterator it = index.begin(); it != index.end(); ++it) {
+				resolved_uri.push_back(base_uri + '/' + *it);
+			}
+		} else {
+			base_uri.append(uri);
+			resolved_uri.push_back(base_uri);
+		}
+	}
+	user_data->request_message_.SetResolvedUri(resolved_uri);
 }

--- a/sources/core/server_socket.cpp
+++ b/sources/core/server_socket.cpp
@@ -8,10 +8,8 @@
 
 const int ServerSocket::BACK_LOG_QUEUE = 5;
 
-ServerSocket::ServerSocket(const std::string &addr,
-						   const server_infos_type &server_infos)
-	: Socket(Socket::SERVER_TYPE), server_infos_(server_infos) {
-
+ServerSocket::ServerSocket(const std::string &addr, const server_infos_type &server_infos)
+: Socket(-1, server_infos) {
 	size_t colon = addr.find(":");
 	std::string host = addr.substr(0, colon);
 	std::string port = addr.substr(colon + 1, addr.length() - (colon + 1));
@@ -67,7 +65,7 @@ struct addrinfo *ServerSocket::GetAddrInfos(const std::string &host,
 void ServerSocket::Bind(struct addrinfo *result) {
 	struct addrinfo *curr;
 	int opt = 1;
-	sock_d_ = -1;
+	// sock_d_ = -1;
 
 	for (curr = result; curr != NULL; curr = curr->ai_next) {
 		sock_d_ = socket(curr->ai_family, curr->ai_socktype, curr->ai_protocol);

--- a/sources/core/socket.cpp
+++ b/sources/core/socket.cpp
@@ -3,7 +3,8 @@
 #include <arpa/inet.h>
 #include <unistd.h>
 
-Socket::Socket(int sock_d) : sock_d_(sock_d) {}
+Socket::Socket(int sock_d, const server_infos_type &server_infos)
+: server_infos_(server_infos), sock_d_(sock_d) {}
 
 Socket::~Socket() {}
 

--- a/sources/core/webserv.cpp
+++ b/sources/core/webserv.cpp
@@ -6,34 +6,34 @@
 #include "unistd.h"
 
 Webserv::Webserv(const server_configs_type &server_configs) {
-    for (server_configs_type::const_iterator it = server_configs.begin();
-         it != server_configs.end(); ++it) {
-        ServerSocket server(it->first, it->second);
-        servers_.insert(std::make_pair(server.GetSocketDescriptor(), server));
-        kq_handler_.AddReadEvent(
-                server.GetSocketDescriptor(),
-                reinterpret_cast<void *>(new Udata(Udata::LISTEN, server.GetSocketDescriptor())));  // LISTEN 이벤트 등록
-    }
+	for (server_configs_type::const_iterator it = server_configs.begin();
+			it != server_configs.end(); ++it) {
+		ServerSocket server(it->first, it->second);
+		servers_.insert(std::make_pair(server.GetSocketDescriptor(), server));
+		kq_handler_.AddReadEvent(
+				server.GetSocketDescriptor(),
+				reinterpret_cast<void *>(new Udata(Udata::LISTEN, server.GetSocketDescriptor())));  // LISTEN 이벤트 등록
+	}
 }
 
 Webserv::~Webserv() {}
 
 // TODO : ISSUE에 이름 바꾸자고 건의하기
 void Webserv::StartServer() {
-    std::cout << "Start server" << std::endl;
-    while (true) {
-        struct kevent event =
-                kq_handler_.MonitorEvent();     // 이벤트 등록 & 이벤트 추출
+	std::cout << "Start server" << std::endl;
+	while (true) {
+		struct kevent event =
+				kq_handler_.MonitorEvent();     // 이벤트 등록 & 이벤트 추출
 
-        if (event.flags & EV_EOF) {
-            std::cout << "Disconnect : " << event.ident << std::endl;
-            Udata *user_data = reinterpret_cast<Udata *>(event.udata);
-            delete user_data;  // Socket is automatically removed from the kq by
-            // the kernel
-            continue;
-        }
-        HandleEvent(event);
-    }
+		if (event.flags & EV_EOF) {
+			std::cout << "Disconnect : " << event.ident << std::endl;
+			Udata *user_data = reinterpret_cast<Udata *>(event.udata);
+			delete user_data;  // Socket is automatically removed from the kq by
+			// the kernel
+			continue;
+		}
+		HandleEvent(event);
+	}
 }
 
 ServerSocket &Webserv::FindServerSocket(const int &fd) {
@@ -45,26 +45,26 @@ ClientSocket &Webserv::FindClientSocket(const int &fd) {
 }
 
 void Webserv::HandleEvent(struct kevent &event) {
-    Udata *user_data = reinterpret_cast<Udata *>(event.udata);
-    int event_fd = event.ident;
-    switch (user_data->GetState()) {
-        case Udata::LISTEN:
-            HandleListenEvent(FindServerSocket(event_fd));
-            break;
-        case Udata::RECV_REQUEST:
-            HandleReceiveRequestEvent(FindClientSocket(event_fd), user_data);
-            break;
-        case Udata::READ_FILE:
-            HandleReadFile(user_data, event_fd);
-            break;    // GET
-        case Udata::WRITE_TO_PIPE:
-            break;    // CGI
-        case Udata::READ_FROM_PIPE:
-            break;    // CGI
-        case Udata::SEND_RESPONSE:
-            HandleSendResponseEvent(FindClientSocket(event_fd), user_data);
-            break;
-    }
+	Udata *user_data = reinterpret_cast<Udata *>(event.udata);
+	int event_fd = event.ident;
+	switch (user_data->GetState()) {
+		case Udata::LISTEN:
+			HandleListenEvent(FindServerSocket(event_fd));
+			break;
+		case Udata::RECV_REQUEST:
+			HandleReceiveRequestEvent(FindClientSocket(event_fd), user_data);
+			break;
+		case Udata::READ_FILE:
+			HandleReadFile(user_data, event_fd);
+			break;    // GET
+		case Udata::WRITE_TO_PIPE:
+			break;    // CGI
+		case Udata::READ_FROM_PIPE:
+			break;    // CGI
+		case Udata::SEND_RESPONSE:
+			HandleSendResponseEvent(FindClientSocket(event_fd), user_data);
+			break;
+	}
 }
 
 void Webserv::HandleListenEvent(const ServerSocket &server_socket) {
@@ -79,63 +79,63 @@ void Webserv::HandleListenEvent(const ServerSocket &server_socket) {
 }
 
 void Webserv::HandleReceiveRequestEvent(ClientSocket &client_socket,
-                                        Udata *user_data) {
-    try {
-        int next_state = EventHandler::HandleRequestEvent(client_socket, user_data);
-        if (next_state == Udata::RECV_REQUEST) {
-            return;
-        }
-        kq_handler_.DeleteReadEvent(client_socket.GetSocketDescriptor());
-        user_data->ChangeState(next_state);
-        if (next_state == Udata::READ_FILE) {
-            kq_handler_.AddReadEvent(OpenFile(*user_data), user_data);
-        } else if (next_state == Udata::READ_FROM_PIPE) {
-            //  kq_handler_.AddReadEvent(OpenPipe(client_socket, *user_data), user_data);
-        } else if (next_state == Udata::WRITE_TO_PIPE) {
-            //  kq_handler_.AddWriteEvent(OpenPipe(client_socket, *user_data), user_data);
-        } else if (next_state == Udata::SEND_RESPONSE) {
-            kq_handler_.AddWriteEvent(client_socket.GetSocketDescriptor(), user_data);
-        }
-    } catch (std::exception &e) {
-        kq_handler_.DeleteReadEvent(client_socket.GetSocketDescriptor());
-        std::cerr << e.what() << std::endl;
-        user_data->ChangeState(Udata::SEND_RESPONSE);
-        kq_handler_.AddWriteEvent(client_socket.GetSocketDescriptor(), user_data);
-    }
+										Udata *user_data) {
+	try {
+		int next_state = EventHandler::HandleRequestEvent(client_socket, user_data);
+		if (next_state == Udata::RECV_REQUEST) {
+			return;
+		}
+		kq_handler_.DeleteReadEvent(client_socket.GetSocketDescriptor());
+		user_data->ChangeState(next_state);
+		if (next_state == Udata::READ_FILE) {
+			kq_handler_.AddReadEvent(OpenFile(*user_data), user_data);
+		} else if (next_state == Udata::READ_FROM_PIPE) {
+			//  kq_handler_.AddReadEvent(OpenPipe(client_socket, *user_data), user_data);
+		} else if (next_state == Udata::WRITE_TO_PIPE) {
+			//  kq_handler_.AddWriteEvent(OpenPipe(client_socket, *user_data), user_data);
+		} else if (next_state == Udata::SEND_RESPONSE) {
+			kq_handler_.AddWriteEvent(client_socket.GetSocketDescriptor(), user_data);
+		}
+	} catch (std::exception &e) {
+		kq_handler_.DeleteReadEvent(client_socket.GetSocketDescriptor());
+		std::cerr << e.what() << std::endl;
+		user_data->ChangeState(Udata::SEND_RESPONSE);
+		kq_handler_.AddWriteEvent(client_socket.GetSocketDescriptor(), user_data);
+	}
 
 }
 
 void Webserv::HandleReadFile(Udata *user_data, int fd) {
-    // Get Request만 들어왔을때 가정
-    // 저장해주는 객체 필요함 (udata에 저장) 만들 예정
-    char buf[BUFFER_SIZE + 1];
-    int size = read(fd, buf, BUFFER_SIZE);
-    if (size < 0) {
-        std::perror("open: INTERNAL_SERVER_ERROR");
-//        return INTERNAL_SERVER_ERROR;
-    }
-    user_data->response_message_.SetBody(buf);
-    // buf 이하로 읽고 and 성공했다는 가정
-    // test 용도임
-    kq_handler_.DeleteWriteEvent(fd);
-    // 여기서 response 설정을 해줘야함
-    user_data->ChangeState(Udata::SEND_RESPONSE);
-    kq_handler_.AddWriteEvent(user_data->sock_d_, user_data);
+	// Get Request만 들어왔을때 가정
+	// 저장해주는 객체 필요함 (udata에 저장) 만들 예정
+	char buf[BUFFER_SIZE + 1];
+	int size = read(fd, buf, BUFFER_SIZE);
+	if (size < 0) {
+		std::perror("open: INTERNAL_SERVER_ERROR");
+		// return INTERNAL_SERVER_ERROR;
+	}
+	user_data->response_message_.SetBody(buf);
+	// buf 이하로 읽고 and 성공했다는 가정
+	// test 용도임
+	kq_handler_.DeleteWriteEvent(fd);
+	// 여기서 response 설정을 해줘야함
+	user_data->ChangeState(Udata::SEND_RESPONSE);
+	kq_handler_.AddWriteEvent(user_data->sock_d_, user_data);
 }
 
 void Webserv::HandleSendResponseEvent(const ClientSocket &client_socket,
-                                      Udata *user_data) {
-    int result = EventHandler::HandleResponseEvent(client_socket, user_data);
-    if (result == EventHandler::KEEP_ALIVE) {
-        kq_handler_.DeleteWriteEvent(
-                client_socket.GetSocketDescriptor());  // event 삭제
-        user_data->Reset(); // change state도 함께 일어남
-        kq_handler_.AddReadEvent(client_socket.GetSocketDescriptor(),
-                                 user_data);  // read event 등록
-    } else if (result == EventHandler::CLOSE) {
-        // clients에서 client 소켓 삭제
-        delete user_data;
-    } else if (result == EventHandler::ERROR) {
-    }
-    // HAS_MORE
+										Udata *user_data) {
+	int result = EventHandler::HandleResponseEvent(client_socket, user_data);
+	if (result == EventHandler::KEEP_ALIVE) {
+		kq_handler_.DeleteWriteEvent(
+				client_socket.GetSocketDescriptor());  // event 삭제
+		user_data->Reset(); // change state도 함께 일어남
+		kq_handler_.AddReadEvent(client_socket.GetSocketDescriptor(),
+									user_data);  // read event 등록
+	} else if (result == EventHandler::CLOSE) {
+		// clients에서 client 소켓 삭제
+		delete user_data;
+	} else if (result == EventHandler::ERROR) {
+	}
+	// HAS_MORE
 }

--- a/sources/exception/http_exception.cpp
+++ b/sources/exception/http_exception.cpp
@@ -14,5 +14,5 @@ const char *HttpException::what() const throw() {
 }
 
 int HttpException::GetStatusCode() const {
-    return status_code_;
+	return status_code_;
 }

--- a/sources/response/get_method.cpp
+++ b/sources/response/get_method.cpp
@@ -11,29 +11,29 @@
 #define BUFFER_SIZE 1024
 
 int GetMethod(std::string uri, std::string &body_entity) {
-    char buf[BUFFER_SIZE + 1];
-    int fd = open(uri.c_str(), O_RDONLY);
-    if (fd < 0) {
-        if (errno == ENOENT) {
-            std::perror("open: NOT_FOUND");
-            return NOT_FOUND;
-        }
-        if (errno == EACCES) {
-            std::perror("open: FORBIDDEN");
-            return FORBIDDEN;
-        }
-    }
-    int size = read(fd, buf, BUFFER_SIZE);
-    while (size > 0) { // NONBLOCK 처리 필요
-        buf[size] = 0;
-        body_entity.append(buf);
-        size = read(fd, buf, BUFFER_SIZE);
-    }
-    close(fd);
-    if (size < 0) {
-        body_entity.clear();
-        std::perror("open: INTERNAL_SERVER_ERROR");
-        return INTERNAL_SERVER_ERROR;
-    }
-    return OK;
+	char buf[BUFFER_SIZE + 1];
+	int fd = open(uri.c_str(), O_RDONLY);
+	if (fd < 0) {
+		if (errno == ENOENT) {
+			std::perror("open: NOT_FOUND");
+			return NOT_FOUND;
+		}
+		if (errno == EACCES) {
+			std::perror("open: FORBIDDEN");
+			return FORBIDDEN;
+		}
+	}
+	int size = read(fd, buf, BUFFER_SIZE);
+	while (size > 0) { // NONBLOCK 처리 필요
+		buf[size] = 0;
+		body_entity.append(buf);
+		size = read(fd, buf, BUFFER_SIZE);
+	}
+	close(fd);
+	if (size < 0) {
+		body_entity.clear();
+		std::perror("open: INTERNAL_SERVER_ERROR");
+		return INTERNAL_SERVER_ERROR;
+	}
+	return OK;
 }

--- a/sources/response/post_method.cpp
+++ b/sources/response/post_method.cpp
@@ -13,11 +13,11 @@
 
 
 static bool IsCGI(std::string uri, std::string cgi_uri) {
-    // conf file 의 location block 안에 cgi_path 가 있는지 없는지 판단
-    // TEST
-    if (uri.find(cgi_uri) == 0)
-        return true;
-    return false;
+	// conf file 의 location block 안에 cgi_path 가 있는지 없는지 판단
+	// TEST
+	if (uri.find(cgi_uri) == 0)
+		return true;
+	return false;
 }
 //location /abcgi/ {
 //    cgi_path: phphcgi;
@@ -25,40 +25,40 @@ static bool IsCGI(std::string uri, std::string cgi_uri) {
 //};
 
 int PostMethod(std::string uri, std::string &body_entity) {
-    std::string cgi_uri("/cgi/"); // TEST 일단 cgi_path를 '/cgi' 로 초기화 함
-    std::string form_uri("/"); // form data로 요청이 들어왔을때.
-    std::string root("./");
+	std::string cgi_uri("/cgi/"); // TEST 일단 cgi_path를 '/cgi' 로 초기화 함
+	std::string form_uri("/"); // form data로 요청이 들어왔을때.
+	std::string root("./");
 
-    // if cgi
-    if (IsCGI(uri, cgi_uri)) {
-        // run CGI
-        return OK;
-    }
-    else {
-        char buf[BUFFER_SIZE + 1];
-        int fd = open((root + uri).c_str(), O_RDONLY);
-        if (fd < 0) {
-            if (errno == ENOENT) {
-                std::perror("open: NOT_FOUND");
-                return NOT_FOUND;
-            }
-            if (errno == EACCES) {
-                std::perror("open: FORBIDDEN");
-                return FORBIDDEN;
-            }
-        }
-        int size = read(fd, buf, BUFFER_SIZE);
-        while (size > 0) { // NONBLOCK 처리 필요
-            buf[size] = 0;
-            body_entity.append(buf);
-            size = read(fd, buf, BUFFER_SIZE);
-        }
-        close(fd);
-        if (size < 0) {
-            body_entity.clear();
-            std::perror("open: INTERNAL_SERVER_ERROR");
-            return INTERNAL_SERVER_ERROR;
-        }
-    }
-    return OK;
+	// if cgi
+	if (IsCGI(uri, cgi_uri)) {
+		// run CGI
+		return OK;
+	}
+	else {
+		char buf[BUFFER_SIZE + 1];
+		int fd = open((root + uri).c_str(), O_RDONLY);
+		if (fd < 0) {
+			if (errno == ENOENT) {
+				std::perror("open: NOT_FOUND");
+				return NOT_FOUND;
+			}
+			if (errno == EACCES) {
+				std::perror("open: FORBIDDEN");
+				return FORBIDDEN;
+			}
+		}
+		int size = read(fd, buf, BUFFER_SIZE);
+		while (size > 0) { // NONBLOCK 처리 필요
+			buf[size] = 0;
+			body_entity.append(buf);
+			size = read(fd, buf, BUFFER_SIZE);
+		}
+		close(fd);
+		if (size < 0) {
+			body_entity.clear();
+			std::perror("open: INTERNAL_SERVER_ERROR");
+			return INTERNAL_SERVER_ERROR;
+		}
+	}
+	return OK;
 }


### PR DESCRIPTION
- Space4개 Tab으로 수정
- ServerSocket의 생성자에서 Type을 받아 초기화 하던 부분(deprecated) 변경 안 되어있어서 수정함.
- ServerSocket과 ClientSocket이 모두 server_infos를 갖고 있어서, 이를 Socket이 가지도록 수정함.
- 불필요한 explicit키워드 제거함.

브랜치 삭제하지 말아주세요