### PR TITLE
Request에서 Statuscode 제거

### DIFF
--- a/includes/request/request_message.hpp
+++ b/includes/request/request_message.hpp
@@ -23,7 +23,6 @@ class RequestMessage {
 
 	/* GETTER */
 	int					GetClientMaxBodySize() const;
-	StatusCode			GetStatusCode() const;
 	int					GetContentSize() const;
 	bool 				IsChunked() const;
 	bool				IsAlive() const;
@@ -47,7 +46,6 @@ class RequestMessage {
 	/* SETTER */
 	void SetClientMaxBodySize(int max_size);
 	void SetState(RequestState code);
-	void SetStatusCode(StatusCode code);
 	void SetContentSize(int size);
 	void SetChunked(bool is_chunked);
 	void SetConnection(bool is_keep_alive);
@@ -73,7 +71,6 @@ class RequestMessage {
    private:
 	int client_max_body_size_;
 
-	StatusCode	status_code_;
 	int content_size_;
 	bool is_chunked_;
 	bool keep_alive_;

--- a/includes/request/request_message.hpp
+++ b/includes/request/request_message.hpp
@@ -99,6 +99,7 @@ class RequestMessage {
 
     /* 가공된 Request Message */
     std::vector<std::string> resolved_uri_;
+	//TODO: is_cgi_ boolean flag 추가하기
 };
 
 std::ostream &operator<<(std::ostream &os, const RequestMessage &req_msg);

--- a/includes/request/request_message.hpp
+++ b/includes/request/request_message.hpp
@@ -42,7 +42,6 @@ class RequestMessage {
 	const headers_type	&GetHeaders() const;
 	const std::string	&GetBody() const;
 
-	// TODO : 이거 물어보기. 뭔지.
 	const std::vector<std::string> &GetResolvedUri() const;
 
 	/* SETTER */

--- a/includes/request/request_parser.hpp
+++ b/includes/request/request_parser.hpp
@@ -17,16 +17,6 @@ void ParseRequest(RequestMessage &req_msg,
 					const char *input);
 size_t ParseChunkedRequest(RequestMessage & req_msg, const char * input);
 
-// TODO : 위가 develop에 있던 부분인데, 선택해야함.
-/* CHECKER */
-// void CheckProtocol(RequestMessage& req_msg, const std::string& protocol);
-// bool CheckHeaderField(const RequestMessage& req_msg);
-// bool IsThereHost(const RequestMessage& req_msg);
-// bool CheckSingleHeaderName(const RequestMessage& req_msg);
-// bool RequestStartlineCheck(RequestMessage& req_msg,
-// 						   const ServerInfo& server_info);
-// bool RequestHeaderCheck(RequestMessage& req_msg, const ServerInfo& server_info);
-
 /* CHECKER */
 void CheckProtocol(RequestMessage & req_msg, const std::string & protocol);
 bool CheckSingleHeaderName(const RequestMessage & req_msg);

--- a/sources/core/event_executor.cpp
+++ b/sources/core/event_executor.cpp
@@ -37,20 +37,15 @@ int EventExecutor::ReceiveRequest(ClientSocket &client_socket,
 		ParseRequest(request, server_infos, tmp);
 		if (request.GetState() == DONE) {
 			std::cout << C_BOLD << C_BLUE << "PARSE DONE!" << C_RESET << std::endl;
+			Resolve_URI(client_socket, request, user_data);
 			std::cout << request << std::endl;
+		
 			//TODO: 이 clear는 임시로 추가 한 것이다. 이후에는 response이후에 클리어 된다.
-			request.Clear();
-			// if (request.GetMethod() == "GET") {
-			// 	return Udata::READ_FILE;
-			// }
+			// request.Clear();
+			if (request.GetMethod() == "GET") {
+				return Udata::READ_FILE;
+			}
 		} 
-		// else if (request.GetState() == HEADER_END) { // socket info 정하고, request validation 체크하고, uri resolve
-		// 	// client_socket.FindServerInfoWithHost(request.GetHeader()); // request에 GetHeader 구현 필요
-		// 	client_socket.FindLocationWithUri(request.GetUri());
-		// 	RequestValidationCheck(client_socket);
-		// 	Resolve_URI(client_socket, request, user_data);
-		// 	// exception 처리 내부에서 해줌 response 설정까지 해줘야함
-		// } -> 이 부분이 ParseRequest로 들어감.
 	} catch (const HttpException &e) {
 		std::cerr << C_RED << "Exception has been thrown" << C_RESET << std::endl; // debugging
 		std::cerr << C_RED << e.what() << C_RESET << std::endl; // debugging

--- a/sources/core/event_executor.cpp
+++ b/sources/core/event_executor.cpp
@@ -41,10 +41,10 @@ int EventExecutor::ReceiveRequest(ClientSocket &client_socket,
 			std::cout << request << std::endl;
 		
 			//TODO: 이 clear는 임시로 추가 한 것이다. 이후에는 response이후에 클리어 된다.
-			// request.Clear();
-			if (request.GetMethod() == "GET") {
-				return Udata::READ_FILE;
-			}
+			request.Clear();
+			// if (request.GetMethod() == "GET") {
+			// 	return Udata::READ_FILE;
+			// }
 		} 
 	} catch (const HttpException &e) {
 		std::cerr << C_RED << "Exception has been thrown" << C_RESET << std::endl; // debugging

--- a/sources/core/fd_handler.cpp
+++ b/sources/core/fd_handler.cpp
@@ -24,6 +24,7 @@ int OpenFile(const Udata &user_data) {
 				throw (HTTP_EXCEPTION(FORBIDDEN));
 			}
 		}
+		// TODO : open 성공하면 return 하는 부분 추가 @seungsle
 	}
 	return fd;
 }

--- a/sources/core/resolve_uri.cpp
+++ b/sources/core/resolve_uri.cpp
@@ -52,4 +52,5 @@ void Resolve_URI(const ClientSocket &client, const RequestMessage &request, Udat
 		}
 	}
 	user_data->request_message_.SetResolvedUri(resolved_uri);
+	//TODO: CGI 여부 판단해서 request_message에 flag설정
 }

--- a/sources/request/request_message.cpp
+++ b/sources/request/request_message.cpp
@@ -91,6 +91,11 @@ std::ostream &operator<<(std::ostream &os, const RequestMessage &req_msg) {
 	os << "[Body Size ] : " << req_msg.GetContentSize() << std::endl;
 	os << "[StatusCode] : " << req_msg.GetStatusCode() << std::endl;
 	os << "[Connection] : " << (req_msg.IsAlive() ? "alive" : "close") << std::endl;
+	os << "[   URI    ] : " ;
+	const std::vector<std::string> &uri = req_msg.GetResolvedUri();
+	for (std::vector<std::string>::const_iterator it = uri.begin() ; it != uri.end() ; it++)
+		os << *it << " | ";
+	os << std::endl;
 	os << "=======================================" << C_RESET << std::endl;
 	return os;
 }

--- a/sources/request/request_message.cpp
+++ b/sources/request/request_message.cpp
@@ -12,7 +12,6 @@ RequestMessage::RequestMessage(int client_max_body_size)
 RequestMessage::~RequestMessage() {}
 
 void RequestMessage::Clear() {
-	status_code_ = CONTINUE;
 	content_size_ = 0;
 	is_chunked_ = false;
 	keep_alive_ = true;
@@ -89,7 +88,6 @@ std::ostream &operator<<(std::ostream &os, const RequestMessage &req_msg) {
 	os << req_msg.GetBody() << C_RESET << std::endl;
 	os << C_ITALIC << C_LIGHTCYAN << "---------------------------------------" << std::endl;
 	os << "[Body Size ] : " << req_msg.GetContentSize() << std::endl;
-	os << "[StatusCode] : " << req_msg.GetStatusCode() << std::endl;
 	os << "[Connection] : " << (req_msg.IsAlive() ? "alive" : "close") << std::endl;
 	os << "[   URI    ] : " ;
 	const std::vector<std::string> &uri = req_msg.GetResolvedUri();

--- a/sources/request/request_message_getter_setter.cpp
+++ b/sources/request/request_message_getter_setter.cpp
@@ -4,10 +4,6 @@ int	RequestMessage::GetClientMaxBodySize() const {
 	return (client_max_body_size_);
 }
 
-StatusCode	RequestMessage::GetStatusCode() const {
-	return (status_code_);
-}
-
 int	RequestMessage::GetContentSize() const {
 	return (content_size_);
 }
@@ -80,10 +76,6 @@ void RequestMessage::SetClientMaxBodySize(int max_size) {
 
 void RequestMessage::SetState(RequestState code) {
 	state_ = code;
-}
-
-void RequestMessage::SetStatusCode(StatusCode code) {
-	status_code_ = code;
 }
 
 void RequestMessage::SetChunked(bool is_chunked) {


### PR DESCRIPTION
- 기존에는 parsing단계에서 예외가 발생하면 그 때 exception을 throw하지 않고, return 후 밖에서 한번에 예외 처리 하였음. (request_message가 status_code를 가지고 있었음.)
- request_message에서 status_code를 분리하고, 예외사항이 발생할 때 그 때 그 때 throw하도록 수정함.