### PR TITLE
HttpException 생성자 변경

### DIFF
--- a/includes/exception/http_exception.hpp
+++ b/includes/exception/http_exception.hpp
@@ -5,12 +5,14 @@
 
 class HttpException : public std::exception {
    public:
-	HttpException(int status_code);
+	HttpException(int status_code, const std::string &message = "unknown");
+	~HttpException() throw();
 	const char *what() const throw();
 
 	int GetStatusCode() const;
 
 private:
+	std::string err_msg_;
 	int status_code_;
 };
 

--- a/includes/request/request_parser.hpp
+++ b/includes/request/request_parser.hpp
@@ -19,7 +19,7 @@ size_t ParseChunkedRequest(RequestMessage & req_msg, const char * input);
 
 /* CHECKER */
 void CheckProtocol(RequestMessage & req_msg, const std::string & protocol);
-bool CheckSingleHeaderName(const RequestMessage & req_msg);
+void CheckSingleHeaderName(RequestMessage & req_msg);
 void CheckRequest(RequestMessage & req_msg, const std::vector<ServerInfo> &server_infos);
 
 bool CheckHeaderField(const RequestMessage & req_msg);

--- a/includes/util/util.hpp
+++ b/includes/util/util.hpp
@@ -1,0 +1,8 @@
+#ifndef UTIL_HPP
+# define UTIL_HPP
+# include <string>
+# include <sstream>
+
+std::string int_to_str(int a);
+
+#endif

--- a/sources/core/event_executor.cpp
+++ b/sources/core/event_executor.cpp
@@ -28,7 +28,7 @@ int EventExecutor::ReceiveRequest(ClientSocket &client_socket,
 	int recv_len = recv(client_socket.GetSocketDescriptor(),
 						tmp, sizeof(tmp), 0);
 	if (recv_len < 0) {
-		throw (HttpException(INTERNAL_SERVER_ERROR));
+		throw (HttpException(INTERNAL_SERVER_ERROR, "(event_executor) : recv errror"));
 	}
 	tmp[recv_len] = '\0';
 	try {

--- a/sources/exception/http_exception.cpp
+++ b/sources/exception/http_exception.cpp
@@ -1,33 +1,15 @@
 #include "http_exception.hpp"
 #include "status_code.hpp"
 
-HttpException::HttpException(int status_code) : status_code_(status_code) {}
+HttpException::HttpException(int status_code, const std::string &message)
+: status_code_(status_code) {
+	err_msg_ = std::to_string(status_code) + " | " + message;
+}
+
+HttpException::~HttpException() throw() {}
 
 const char *HttpException::what() const throw() {
-	if (status_code_ == BAD_REQUEST)
-		return ("400: Bad Request");
-	else if (status_code_ == FORBIDDEN)
-		return ("403 : Forbidden");
-	else if (status_code_ == NOT_FOUND)
-		return ("404 : Not Found");
-	else if (status_code_ == METHOD_NOT_ALLOWED)
-		return ("405 : Method not allowed");
-	else if (status_code_ == NOT_ACCEPTABLE)
-		return ("406 : Not acceptable");
-	else if (status_code_ == LENGTH_REQUIRED)
-		return ("411 : Length Required");
-	else if (status_code_ == PAYLOAD_TOO_LARGE)
-		return ("413 : Payload too large");
-	else if (status_code_ == URI_TOO_LONG)
-		return ("414 : URI too long");
-	else if (status_code_ == INTERNAL_SERVER_ERROR)
-		return ("500 : Internal server error");
-	else if (status_code_ == NOT_IMPLEMENTED)
-		return ("501 : Not Implemented");
-	else if (status_code_ == HTTP_VERSION_NOT_SUPPORTED)
-		return ("505 : HTTP version not supported");
-	else
-		return ("Another Status");
+	return (err_msg_.c_str());
 }
 
 int HttpException::GetStatusCode() const {

--- a/sources/exception/http_exception.cpp
+++ b/sources/exception/http_exception.cpp
@@ -1,9 +1,10 @@
 #include "http_exception.hpp"
 #include "status_code.hpp"
+#include "util.hpp"
 
 HttpException::HttpException(int status_code, const std::string &message)
 : status_code_(status_code) {
-	err_msg_ = std::to_string(status_code) + " | " + message;
+	err_msg_ = int_to_str(status_code) + " | " + message;
 }
 
 HttpException::~HttpException() throw() {}

--- a/sources/request/request_chunked_parser.cpp
+++ b/sources/request/request_chunked_parser.cpp
@@ -3,6 +3,7 @@
 
 #include "request_parser.hpp"
 #include "http_exception.hpp"
+#include "util.hpp"
 
 static RequestState ChunkStart(RequestMessage &req_msg,char c);
 static RequestState ChunkSize(RequestMessage &req_msg,char c);
@@ -106,9 +107,9 @@ static RequestState ChunkSizeCRLF(RequestMessage &req_msg,char c) {
 			return BODY_CHUNK_LASTDATA; // -> 0 혹은 extension 이후에 CRLF를 만나면 LASTDATA로 간다.
 		if (chunk_size + req_msg.GetChunkSize() > req_msg.GetClientMaxBodySize()) {
 			std::string err_msg = "(chunked parser) : max client body size is "\
-								+ std::to_string(req_msg.GetClientMaxBodySize())\
+								+ int_to_str(req_msg.GetClientMaxBodySize())\
 								+ ". input size is "\
-								+ std::to_string(chunk_size + req_msg.GetChunkSize());
+								+ int_to_str(chunk_size + req_msg.GetChunkSize());
 			throw HttpException(PAYLOAD_TOO_LARGE, err_msg.c_str());
 		}
 		req_msg.SetChunkSize(chunk_size);

--- a/sources/request/request_chunked_parser.cpp
+++ b/sources/request/request_chunked_parser.cpp
@@ -29,21 +29,37 @@ size_t ParseChunkedRequest(RequestMessage & req_msg, const char * input) {
 	{
 		switch (req_msg.GetState())
 		{
-			case BODY_CHUNK_START : 			req_msg.SetState(ChunkStart(req_msg, *input)); break ;
-			case BODY_CHUNK_SIZE : 				req_msg.SetState(ChunkSize(req_msg, *input)); break ;
-			case BODY_CHUNK_SIZE_CRLF : 		req_msg.SetState(ChunkSizeCRLF(req_msg, *input)); break ;
-			case BODY_CHUNK_EXTENSION : 		req_msg.SetState(ChunkExtension(*input)); break ;
-			case BODY_CHUNK_EXTENSION_NAME : 	req_msg.SetState(ChunkExtensionName(*input)); break ;
-			case BODY_CHUNK_EXTENSION_VALUE : 	req_msg.SetState(ChunkExtensionValue(*input)); break ;
-			case BODY_CHUNK_DATA : 				req_msg.SetState(ChunkData(req_msg, *input)); break ;
-			case BODY_CHUNK_LASTDATA : 			req_msg.SetState(ChunkLastData(req_msg, *input)); break ;
-			case BODY_CHUNK_CRLF : 				req_msg.SetState(ChunkCRLF(req_msg, *input)); break ;
-			case BODY_CHUNK_TRAILER : 			req_msg.SetState(ChunkTrailer(*input)); break ;
-			case BODY_CHUNK_TRAILER_NAME : 		req_msg.SetState(ChunkTrailerName(*input)); break ;
-			case BODY_CHUNK_TRAILER_VALUE : 	req_msg.SetState(ChunkTrailerValue(*input)); break ;
-			case BODY_CHUNK_TRAILER_CRLF : 		req_msg.SetState(ChunkTrailerCRLF(*input)); break ;
-			case BODY_CHUNK_EMPTYLINE : 		req_msg.SetState(ChunkEmptyLine(*input)); break ;
-			default :							throw HttpException(BAD_REQUEST); break;
+			case BODY_CHUNK_START :
+				req_msg.SetState(ChunkStart(req_msg, *input)); break ;
+			case BODY_CHUNK_SIZE :
+				req_msg.SetState(ChunkSize(req_msg, *input)); break ;
+			case BODY_CHUNK_SIZE_CRLF :
+				req_msg.SetState(ChunkSizeCRLF(req_msg, *input)); break ;
+			case BODY_CHUNK_EXTENSION :
+				req_msg.SetState(ChunkExtension(*input)); break ;
+			case BODY_CHUNK_EXTENSION_NAME :
+				req_msg.SetState(ChunkExtensionName(*input)); break ;
+			case BODY_CHUNK_EXTENSION_VALUE :
+				req_msg.SetState(ChunkExtensionValue(*input)); break ;
+			case BODY_CHUNK_DATA :
+				req_msg.SetState(ChunkData(req_msg, *input)); break ;
+			case BODY_CHUNK_LASTDATA :
+				req_msg.SetState(ChunkLastData(req_msg, *input)); break ;
+			case BODY_CHUNK_CRLF :
+				req_msg.SetState(ChunkCRLF(req_msg, *input)); break ;
+			case BODY_CHUNK_TRAILER :
+				req_msg.SetState(ChunkTrailer(*input)); break ;
+			case BODY_CHUNK_TRAILER_NAME :
+				req_msg.SetState(ChunkTrailerName(*input)); break ;
+			case BODY_CHUNK_TRAILER_VALUE :
+				req_msg.SetState(ChunkTrailerValue(*input)); break ;
+			case BODY_CHUNK_TRAILER_CRLF :
+				req_msg.SetState(ChunkTrailerCRLF(*input)); break ;
+			case BODY_CHUNK_EMPTYLINE :
+				req_msg.SetState(ChunkEmptyLine(*input)); break ;
+			default :
+				throw HttpException(BAD_REQUEST, "(chunked parser) : unknown");
+				break;
 		}
 		input++;
 		count++;
@@ -60,7 +76,8 @@ static RequestState ChunkStart(RequestMessage &req_msg,char c) {
 		return BODY_CHUNK_SIZE;
 	}
 	else
-		throw HttpException(BAD_REQUEST);
+		throw HttpException(BAD_REQUEST, 
+			"(chunked parser) : syntax error. chunk size should be hex-digit");
 }
 
 static RequestState ChunkSize(RequestMessage &req_msg,char c) {
@@ -74,19 +91,26 @@ static RequestState ChunkSize(RequestMessage &req_msg,char c) {
 		return BODY_CHUNK_SIZE;
 	}
 	else
-		throw HttpException(BAD_REQUEST);
+		throw HttpException(BAD_REQUEST,
+			"(chunked parser) : syntax error. chunk size should be hex-digit");
 }
 
 static RequestState ChunkSizeCRLF(RequestMessage &req_msg,char c) {
 	if (c != LF)
-		throw HttpException(BAD_REQUEST);
+		throw HttpException(BAD_REQUEST,
+			"(chunked parser) : syntax error. bare CR not allowed in chunk size line");
 	else
 	{
 		int chunk_size = hexstrToDec(req_msg.GetChunkSizeStr());
 		if (chunk_size == 0)
 			return BODY_CHUNK_LASTDATA; // -> 0 혹은 extension 이후에 CRLF를 만나면 LASTDATA로 간다.
-		if (chunk_size + req_msg.GetChunkSize() > req_msg.GetClientMaxBodySize())
-			throw HttpException(PAYLOAD_TOO_LARGE);
+		if (chunk_size + req_msg.GetChunkSize() > req_msg.GetClientMaxBodySize()) {
+			std::string err_msg = "(chunked parser) : max client body size is "\
+								+ std::to_string(req_msg.GetClientMaxBodySize())\
+								+ ". input size is "\
+								+ std::to_string(chunk_size + req_msg.GetChunkSize());
+			throw HttpException(PAYLOAD_TOO_LARGE, err_msg.c_str());
+		}
 		req_msg.SetChunkSize(chunk_size);
 		return BODY_CHUNK_DATA;
 	}
@@ -98,7 +122,8 @@ static RequestState ChunkExtension(char c) {
 	else if (c == ';')
 		return BODY_CHUNK_EXTENSION_NAME;
 	else
-		throw HttpException(BAD_REQUEST);
+		throw HttpException(BAD_REQUEST,
+			"(chunked parser) : syntax error. ");
 }
 
 static RequestState ChunkExtensionName(char c) {
@@ -109,7 +134,8 @@ static RequestState ChunkExtensionName(char c) {
 	else if (c == CR)
 		return BODY_CHUNK_SIZE_CRLF;
 	else
-		throw HttpException(BAD_REQUEST);
+		throw HttpException(BAD_REQUEST,
+			"(chunked parser) : chunk extension name error");
 }
 
 static RequestState ChunkExtensionValue(char c) {
@@ -120,7 +146,8 @@ static RequestState ChunkExtensionValue(char c) {
 	else if (c == CR)
 		return BODY_CHUNK_SIZE_CRLF;
 	else
-		throw HttpException(BAD_REQUEST);
+		throw HttpException(BAD_REQUEST,
+			"(chunked parser) : chunk extension value error");
 }
 
 static RequestState ChunkData(RequestMessage &req_msg,char c) {
@@ -130,7 +157,8 @@ static RequestState ChunkData(RequestMessage &req_msg,char c) {
 		if (c == CR)
 			return BODY_CHUNK_CRLF;
 		else // RFC에 사이즈와 CLRF가 다르면 어떨 지 안나와있다. 일단 에러처리함.
-			throw HttpException(BAD_REQUEST);
+			throw HttpException(BAD_REQUEST,
+				"(chunked parser) : chunk size differs to actual chunk body size");
 	}
 	else if (0 <= c && c <= 127)
 	{
@@ -139,7 +167,8 @@ static RequestState ChunkData(RequestMessage &req_msg,char c) {
 		return BODY_CHUNK_DATA;
 	}
 	else
-		throw HttpException(BAD_REQUEST);
+		throw HttpException(BAD_REQUEST,
+			"(chunked parser) : syntax error. invalid char for chunk data");
 }
 
 static RequestState ChunkLastData(RequestMessage &req_msg,char c) {
@@ -149,7 +178,8 @@ static RequestState ChunkLastData(RequestMessage &req_msg,char c) {
 	else if (isToken(c) == true)
 		return BODY_CHUNK_TRAILER_NAME;
 	else
-		throw HttpException(BAD_REQUEST);
+		throw HttpException(BAD_REQUEST,
+			"(chunked parser) : syntax error. invalid char for last chunk");
 }
 
 static RequestState ChunkCRLF(RequestMessage &req_msg,char c) {
@@ -163,7 +193,8 @@ static RequestState ChunkCRLF(RequestMessage &req_msg,char c) {
 		return BODY_CHUNK_START;
 	}
 	else
-		throw HttpException(BAD_REQUEST);
+		throw HttpException(BAD_REQUEST,
+			"(chunked parser) : syntax error. bare CR not allowd in chunk body");
 }
 
 static RequestState ChunkTrailer(char c) {
@@ -172,7 +203,8 @@ static RequestState ChunkTrailer(char c) {
 	else if (isToken(c) == true)
 		return BODY_CHUNK_TRAILER_NAME;
 	else
-		throw HttpException(BAD_REQUEST);
+		throw HttpException(BAD_REQUEST,
+			"(chunked parser) : syntax error. invalid char for chunk trailer");
 }
 
 static RequestState ChunkTrailerName(char c) {
@@ -181,7 +213,8 @@ static RequestState ChunkTrailerName(char c) {
 	else if (isToken(c) == true)
 		return BODY_CHUNK_TRAILER_NAME;
 	else
-		throw HttpException(BAD_REQUEST);
+		throw HttpException(BAD_REQUEST,
+			"(chunked parser) : syntax error. invalid char for chunk trailer name");
 }
 
 static RequestState ChunkTrailerValue(char c) {
@@ -190,19 +223,22 @@ static RequestState ChunkTrailerValue(char c) {
 	else if (c == CR)
 		return BODY_CHUNK_TRAILER_CRLF;
 	else
-		throw HttpException(BAD_REQUEST);
+		throw HttpException(BAD_REQUEST,
+			"(chunked parser) : syntax error. invalid char for chunk trailer value");
 }
 
 static RequestState ChunkTrailerCRLF(char c) {
 	if (c == LF)
 		return BODY_CHUNK_TRAILER;
 	else
-		throw HttpException(BAD_REQUEST);
+		throw HttpException(BAD_REQUEST,
+			"(chunked parser) : syntax error. bare CR not allowed in chunk trailer");
 }
 
 static RequestState ChunkEmptyLine(char c) {
 	if (c == LF)
 		return DONE;
 	else
-		throw HttpException(BAD_REQUEST);
+		throw HttpException(BAD_REQUEST,
+			"(chunked parser) : syntax error. bare CR not allowed in last empty line");
 }

--- a/sources/request/request_validation.cpp
+++ b/sources/request/request_validation.cpp
@@ -65,13 +65,18 @@ void CheckProtocol(RequestMessage & req_msg, const std::string & protocol)
 }
 
 // 각 headername이 중복인지 확인
-bool CheckSingleHeaderName(const RequestMessage & req_msg)  {
+void CheckSingleHeaderName(RequestMessage & req_msg)  {
 	const std::string & target_headername = req_msg.GetTempHeaderName();
-	if (target_headername.size() == 0)
-		return false;
-	if (req_msg.GetHeaders().find(target_headername) == req_msg.GetHeaders().end())
-		return true;
-	return false;
+	if (target_headername.size() == 0) {
+		req_msg.SetConnection(false);
+		throw HttpException(BAD_REQUEST,
+			"(header validation) : empty header name");
+	}
+	if (req_msg.GetHeaders().find(target_headername) != req_msg.GetHeaders().end()) {
+		req_msg.SetConnection(false);
+		throw HttpException(BAD_REQUEST,
+			"(header validation) : duplicate header name");
+	}
 }
 
 

--- a/sources/request/request_validation.cpp
+++ b/sources/request/request_validation.cpp
@@ -1,6 +1,7 @@
 #include <sstream>
 #include <algorithm>
 
+#include "util.hpp"
 #include "request_parser.hpp"
 #include "status_code.hpp"
 #include "server_info.hpp"
@@ -177,9 +178,9 @@ bool CheckBodySize(RequestMessage &req_msg) {
 	else if ( (it != headers_map.end()) && (req_msg.GetContentSize() > req_msg.GetClientMaxBodySize()) ) {
 		req_msg.SetConnection(false);
 		std::string err_msg = "(length invalid) : max client body size is "\
-								+ std::to_string(req_msg.GetClientMaxBodySize())\
+								+ int_to_str(req_msg.GetClientMaxBodySize())\
 								+ ". input size is "\
-								+ std::to_string(req_msg.GetContentSize());
+								+ int_to_str(req_msg.GetContentSize());
 		throw HttpException(PAYLOAD_TOO_LARGE, err_msg);
 	}
 	return (true);

--- a/sources/util/util.cpp
+++ b/sources/util/util.cpp
@@ -1,0 +1,7 @@
+#include "util.hpp"
+
+std::string int_to_str(int a) {
+	std::stringstream ss;
+	ss << a;
+	return ss.str();
+}


### PR DESCRIPTION
- HttpException이 err_msg문자열을 멤버로 가지도록 변경
- 그에 따른 생성자 수정
- "laxer exception specification"에 따른 예외객체 소멸자 명시적으로 작성
- HttpException변경에 따른 생성자 호출 부분 수정. (WIP)

**- 브랜치 삭제 X**