### PR TITLE
Request 수정 및 오류 수정

### DIFF
--- a/includes/config/config_utils.hpp
+++ b/includes/config/config_utils.hpp
@@ -8,7 +8,7 @@
 #include "server_info.hpp"
 
 std::vector<std::string> Split(std::string input, char delimiter);
-const ServerInfo &FindServerInfoToRequestHost(
+std::vector<ServerInfo>::const_iterator FindServerInfoToRequestHost(
 	const std::string &server_name, const std::vector<ServerInfo> &server_infos);
 int FindLocationInfoToUri(const std::string &uri,
 						  const ServerInfo &ServerInfo_);

--- a/includes/config/server_info.hpp
+++ b/includes/config/server_info.hpp
@@ -12,7 +12,7 @@ class ServerInfo {
 	~ServerInfo();
 
 	// getter
-	const int &GetClientMaxBodySize() const;
+	int GetClientMaxBodySize() const;
 	const bool &GetAutoindex() const;
 	const std::string &GetHost() const;
 	const std::string &GetPort() const;
@@ -25,7 +25,7 @@ class ServerInfo {
 	const static std::string &GetErrorLog();
 
 	// setter
-	void SetClientMaxBodySize(const int &x);
+	void SetClientMaxBodySize(int x);
 	void SetAutoindex(const bool &x);
 	void SetHost(const std::string &x);
 	void SetPort(const std::string &x);

--- a/includes/core/client_socket.hpp
+++ b/includes/core/client_socket.hpp
@@ -12,16 +12,16 @@
 class ClientSocket : public Socket {
    public:
 
-	explicit ClientSocket(const int &sock_d,
-						   const server_infos_type &server_infos,
-						   const struct sockaddr_in &address);
+	ClientSocket(int sock_d,
+				const server_infos_type &server_infos,
+				const struct sockaddr_in &address);
 	~ClientSocket();
 
 	bool operator<(const ClientSocket &rhs) const;
 
 	const server_infos_type &GetServerInfoVector() const;
 	const ServerInfo &GetServerInfo() const;
-	const int &GetLocationIndex() const;
+	int GetLocationIndex() const;
 
 	void FindServerInfoWithHost(const std::string &host);
 	void FindLocationWithUri(const std::string &uri);

--- a/includes/core/event_executor.hpp
+++ b/includes/core/event_executor.hpp
@@ -14,7 +14,7 @@ class EventExecutor {
 
 	static int ReceiveRequest(KqueueHandler &kqueue_handler, ClientSocket *client_socket, Udata *user_data);
 
-	static int ReadFile(const int &fd, const int &readable_size,
+	static int ReadFile(int fd, int readable_size,
 						ResponseMessage &response_message);
 
 	static int SendResponse(KqueueHandler &kqueue_handler, ClientSocket *client_socket, Udata *user_data);

--- a/includes/core/socket.hpp
+++ b/includes/core/socket.hpp
@@ -19,7 +19,7 @@ class Socket {
 			   const struct sockaddr_in &address);
 	virtual ~Socket() = 0;
 
-	const int &GetSocketDescriptor() const;
+	int GetSocketDescriptor() const;
 	std::string GetHost() const;
 	std::string GetPort() const;
 

--- a/includes/core/udata.hpp
+++ b/includes/core/udata.hpp
@@ -24,8 +24,8 @@ class Udata {
 	explicit Udata(int state, int sock_d);
 	virtual ~Udata();
 
-	const int &GetState() const;
-	void ChangeState(const int &state);
+	int GetState() const;
+	void ChangeState(int state);
 	void Reset();
 
 	RequestMessage request_message_;

--- a/includes/core/webserv.hpp
+++ b/includes/core/webserv.hpp
@@ -41,8 +41,8 @@ class Webserv {
 
 	static void WriteLog(struct kevent &event);
 
-	ServerSocket *FindServerSocket(const int &fd);
-	ClientSocket *FindClientSocket(const int &fd);
+	ServerSocket *FindServerSocket(int fd);
+	ClientSocket *FindClientSocket(int fd);
 };
 
 #endif

--- a/includes/request/request_message.hpp
+++ b/includes/request/request_message.hpp
@@ -41,6 +41,7 @@ class RequestMessage {
 	const headers_type	&GetHeaders() const;
 	const std::string	&GetBody() const;
 
+	const std::string &GetServerName() const;
 	const std::vector<std::string> &GetResolvedUri() const;
 
 	/* SETTER */

--- a/includes/request/request_parser.hpp
+++ b/includes/request/request_parser.hpp
@@ -5,6 +5,7 @@
 #include "request_message.hpp"
 #include "request_parsing_state.hpp"
 #include "server_info.hpp"
+#include "client_socket.hpp"
 
 /* UTILS */
 bool isToken(char c);
@@ -13,14 +14,14 @@ size_t hexstrToDec(std::string hex_string);
 
 /* PARSER */
 void ParseRequest(RequestMessage &req_msg, 
-					const std::vector<ServerInfo> &server_infos,
+					ClientSocket *client_socket,
 					const char *input);
 size_t ParseChunkedRequest(RequestMessage & req_msg, const char * input);
 
 /* CHECKER */
 void CheckProtocol(RequestMessage & req_msg, const std::string & protocol);
 void CheckSingleHeaderName(RequestMessage & req_msg);
-void CheckRequest(RequestMessage & req_msg, const std::vector<ServerInfo> &server_infos);
+void CheckRequest(RequestMessage & req_msg, ClientSocket *client_socket);
 
 bool CheckHeaderField(const RequestMessage & req_msg);
 

--- a/sources/config/config_utils.cpp
+++ b/sources/config/config_utils.cpp
@@ -15,18 +15,17 @@ std::vector<std::string> Split(std::string input, char delimiter) {
 }
 // Server 서버 네임이 중복이 안된다는 가정하에
 // 이 함수의 리턴 값을 FindLocationInfoToUri() 의 두번째 인자에 넣어준다.
-const ServerInfo &FindServerInfoToRequestHost(
+std::vector<ServerInfo>::const_iterator FindServerInfoToRequestHost(
 	const std::string &server_name,
 	const std::vector<ServerInfo> &server_infos) {
-	if (server_infos.size() == 1) return server_infos[0];
-	for (size_t i = 0; i < server_infos.size(); i++) {
-		for (size_t j = 0; j < server_infos[i].GetServerName().size(); j++) {
-			if (server_infos[i].GetServerName()[j] == server_name) {
-				return server_infos[i];
-			}
+	std::vector<ServerInfo>::const_iterator target_it = server_infos.begin();
+	for (; target_it != server_infos.end(); target_it++) {
+		for (size_t i = 0; i < target_it->GetServerName().size(); i++) {
+			if (target_it->GetServerName()[i] == server_name)
+				return (target_it);
 		}
 	}
-	return server_infos[0];
+	return (server_infos.begin());
 }
 
 int FindLocationInfoToUri(const std::string &uri,

--- a/sources/config/server_info.cpp
+++ b/sources/config/server_info.cpp
@@ -10,7 +10,7 @@ ServerInfo::ServerInfo() : client_max_body_size_(1000000), autoindex_(false), ro
 
 ServerInfo::~ServerInfo() {}
 
-const int &ServerInfo::GetClientMaxBodySize() const {
+int ServerInfo::GetClientMaxBodySize() const {
 	return this->client_max_body_size_;
 }
 const bool &ServerInfo::GetAutoindex() const { return this->autoindex_; }
@@ -36,7 +36,7 @@ const std::string &ServerInfo::GetErrorLog() {
 }
 
 // setter
-void ServerInfo::SetClientMaxBodySize(const int &x) {
+void ServerInfo::SetClientMaxBodySize(int x) {
 	this->client_max_body_size_ = x;
 }
 void ServerInfo::SetAutoindex(const bool &x) { this->autoindex_ = x; }

--- a/sources/core/client_socket.cpp
+++ b/sources/core/client_socket.cpp
@@ -5,7 +5,7 @@
 #include "character_const.hpp"
 #include "request_parser.hpp"
 
-ClientSocket::ClientSocket(const int &sock_d,
+ClientSocket::ClientSocket(int sock_d,
 						   const server_infos_type &server_infos,
 						   const struct sockaddr_in &address)
 	: Socket(sock_d, server_infos, address),
@@ -44,4 +44,4 @@ const ServerInfo &ClientSocket::GetServerInfo() const {
 	return *server_info_it_;
 }
 
-const int &ClientSocket::GetLocationIndex() const { return location_index_; }
+int ClientSocket::GetLocationIndex() const { return location_index_; }

--- a/sources/core/client_socket.cpp
+++ b/sources/core/client_socket.cpp
@@ -13,9 +13,9 @@ ClientSocket::ClientSocket(int sock_d,
 	  location_index_(-1) {}
 
 ClientSocket::~ClientSocket() {
-	// if (close(sock_d_) < 0) {
-	// 	perror("close socket");
-	// }
+	if (close(sock_d_) < 0) {
+		perror("close socket");
+	}
 }
 
 bool ClientSocket::operator<(const ClientSocket &rhs) const {

--- a/sources/core/client_socket.cpp
+++ b/sources/core/client_socket.cpp
@@ -31,10 +31,15 @@ bool ClientSocket::operator<(const ClientSocket &rhs) const {
 //	  state_(REQUEST) {
 
 // host 기준으로 server_block 선택하여 server_info_ 에 저장
-void ClientSocket::FindServerInfoWithHost(const std::string &host) { (void)host; }
+void ClientSocket::FindServerInfoWithHost(const std::string &server_name) {
+	server_info_it_ = ::FindServerInfoToRequestHost(server_name, server_infos_);
+}
+
 // server_infos에서 uri를 기준으로 location의 index를 location_index_에 저장
 // 예외 발생시 execption throw 해주기
-void ClientSocket::FindLocationWithUri(const std::string &uri) { (void)uri; }
+void ClientSocket::FindLocationWithUri(const std::string &uri) { 
+	location_index_ = ::FindLocationInfoToUri(uri, *server_info_it_);
+}
 
 const ClientSocket::server_infos_type &ClientSocket::GetServerInfoVector() const {
 	return (server_infos_);

--- a/sources/core/event_executor.cpp
+++ b/sources/core/event_executor.cpp
@@ -89,7 +89,7 @@ int EventExecutor::ReceiveRequest(KqueueHandler &kqueue_handler,
  * @param response_message
  * @return
  */
-int EventExecutor::ReadFile(const int &fd, const int &readable_size,
+int EventExecutor::ReadFile(int fd, int readable_size,
 							ResponseMessage &response_message) {
 	char buf[ResponseMessage::BUFFER_SIZE];
 	ssize_t size = read(fd, buf, ResponseMessage::BUFFER_SIZE);

--- a/sources/core/event_executor.cpp
+++ b/sources/core/event_executor.cpp
@@ -55,9 +55,7 @@ int EventExecutor::ReceiveRequest(KqueueHandler &kqueue_handler,
 	}
 	tmp[recv_len] = '\0';
 	try {
-		// ParseRequest(request, tmp);
-		const std::vector<ServerInfo> &server_infos = client_socket->GetServerInfoVector();
-		ParseRequest(request, server_infos, tmp);
+		ParseRequest(request, client_socket, tmp);
 		if (request.GetState() == DONE) {
 //			Resolve_URI(client_socket, request, user_data);
 

--- a/sources/core/socket.cpp
+++ b/sources/core/socket.cpp
@@ -14,7 +14,7 @@ Socket::~Socket() {
 	Close();
 }
 
-const int &Socket::GetSocketDescriptor() const { return sock_d_; }
+int Socket::GetSocketDescriptor() const { return sock_d_; }
 
 std::string Socket::GetHost() const {
 	char str[INET_ADDRSTRLEN];

--- a/sources/core/udata.cpp
+++ b/sources/core/udata.cpp
@@ -9,9 +9,9 @@ Udata::Udata(int state, int sock_d)
 
 Udata::~Udata() {}
 
-const int &Udata::GetState() const { return state_; }
+int Udata::GetState() const { return state_; }
 
-void Udata::ChangeState(const int &state) { state_ = state; }
+void Udata::ChangeState(int state) { state_ = state; }
 
 void Udata::Reset() {
 	state_ = RECV_REQUEST;

--- a/sources/core/webserv.cpp
+++ b/sources/core/webserv.cpp
@@ -55,6 +55,7 @@ void Webserv::RunServer() {
 		if (event.flags & EV_EOF) {
 			delete FindClientSocket(event.ident);
 			delete reinterpret_cast<Udata *>(event.udata);  // Socket is automatically removed from the kq
+			clients_.erase(event.ident);
 			continue;
 		}
 		if (event.ident == error_log_fd_ || event.ident == access_log_fd_) { // write log

--- a/sources/core/webserv.cpp
+++ b/sources/core/webserv.cpp
@@ -36,7 +36,7 @@ Webserv::~Webserv() {
  * @param fd
  * @return Server Socket *
  */
-ServerSocket *Webserv::FindServerSocket(const int &fd) {
+ServerSocket *Webserv::FindServerSocket(int fd) {
 	return servers_.find(fd)->second;
 }
 
@@ -45,7 +45,7 @@ ServerSocket *Webserv::FindServerSocket(const int &fd) {
  * @param fd
  * @return Client Socket *
  */
-ClientSocket *Webserv::FindClientSocket(const int &fd) {
+ClientSocket *Webserv::FindClientSocket(int fd) {
 	return clients_.find(fd)->second;
 }
 

--- a/sources/request/request_message_getter_setter.cpp
+++ b/sources/request/request_message_getter_setter.cpp
@@ -66,6 +66,11 @@ const std::string	&RequestMessage::GetBody() const {
 	return (body_);
 }
 
+// 호출 이전에 IsThereHost()를 호출하는 부분이 필요하다.
+const std::string &RequestMessage::GetServerName() const {
+	return (headers_.at("host"));
+}
+
 const std::vector<std::string> &RequestMessage::GetResolvedUri() const {
 	return resolved_uri_;
 }

--- a/sources/request/request_parser.cpp
+++ b/sources/request/request_parser.cpp
@@ -9,7 +9,7 @@ static void ParseHeader(RequestMessage & req_msg, char c);
 static size_t ParseBody(RequestMessage & req_msg, const char * input);
 static size_t ParseUnchunkedBody(RequestMessage & req_msg, const char * input);
 
-void ParseRequest(RequestMessage & req_msg, const std::vector<ServerInfo> &server_infos, const char * input)
+void ParseRequest(RequestMessage & req_msg, ClientSocket *client_socket, const char * input)
 {
 	while (*input != '\0' && req_msg.GetState() != DONE)
 	{
@@ -22,7 +22,7 @@ void ParseRequest(RequestMessage & req_msg, const std::vector<ServerInfo> &serve
 			input += ParseBody(req_msg, input);
 
 		if (req_msg.GetState() == HEADER_CHECK)
-			CheckRequest(req_msg, server_infos);
+			CheckRequest(req_msg, client_socket);
 	}
 }
 


### PR DESCRIPTION
- FindServerInfo~() 함수가 이터레이터 반환하도록 변경
- RequestParser가 ClientSocket*를 받도록 변경
- const int &, int로 대체
- RequsetParser에서 Serverinfo와 ServerLocation정보를 ClientSocket에 저장하도록 수정

- 같은 descriptor로 두 번 접속할 때 recv_error 및 seg_fault 수정 #10be045 #4bc7f0f
***
- commit 꼬여서 다시 수정했습니다.