### PR TITLE
fix 좀비프로세스 생기는 오류 수정

### DIFF
--- a/includes/core/kqueue_handler.hpp
+++ b/includes/core/kqueue_handler.hpp
@@ -13,6 +13,7 @@ class KqueueHandler {
 	void AddReadEvent(uintptr_t ident, void *udata);
 	void AddWriteEvent(uintptr_t ident, void *udata);
 	void AddWriteOnceEvent(uintptr_t ident, void *udata);
+	void AddProcExitEvent(uintptr_t ident);
 	void DeleteReadEvent(uintptr_t ident);
 	void DeleteWriteEvent(uintptr_t ident);
 

--- a/includes/exception/core_exception.hpp
+++ b/includes/exception/core_exception.hpp
@@ -36,6 +36,10 @@ class CoreException {
 	class ReadException : std::exception {
 
 	};
+
+	class CgiExecutionException : std::exception {
+		const char *what() const throw() { return "cgi execution failed"; }
+	};
 };
 
 #endif    // WEBSERV_INCLUDES_CORE_CORE_EXCEPTION_H_

--- a/sources/core/event_executor.cpp
+++ b/sources/core/event_executor.cpp
@@ -148,7 +148,6 @@ void EventExecutor::ReadCgiResultFromPipe(KqueueHandler &kqueue_handler,
 		close(fd);
 		user_data->ChangeState(Udata::SEND_RESPONSE);
 		kqueue_handler.AddWriteEvent(user_data->sock_d_, user_data);
-		wait(0); // wait 해야 한다면 여기서 해야함
 		return;
 	}
 	buf[size] = '\0';

--- a/sources/core/kqueue_handler.cpp
+++ b/sources/core/kqueue_handler.cpp
@@ -35,6 +35,10 @@ void KqueueHandler::AddWriteOnceEvent(uintptr_t ident, void *udata) {
 	CollectEvents(ident, EVFILT_WRITE, EV_ADD | EV_ONESHOT, 0, 0, udata);
 }
 
+void KqueueHandler::AddProcExitEvent(uintptr_t ident) {
+	CollectEvents(ident, EVFILT_PROC, EV_ADD | EV_ONESHOT, NOTE_EXIT, 0, 0);
+}
+
 void KqueueHandler::DeleteReadEvent(uintptr_t ident) {
 	CollectEvents(ident, EVFILT_READ, EV_DELETE, 0, 0, 0);
 }

--- a/sources/core/webserv.cpp
+++ b/sources/core/webserv.cpp
@@ -61,6 +61,10 @@ void Webserv::RunServer() {
 	while (true) {
 		struct kevent event = kq_handler_.MonitorEvent(); // get event
 		ClientSocket *client = FindClientSocket(event.ident);
+		if (event.fflags & NOTE_EXIT) {
+			waitpid(event.ident, 0, WNOHANG);
+			continue;
+		}
 		if ((event.flags & EV_EOF) && client) {
 			clients_.erase(client->GetSocketDescriptor());
 			delete client;

--- a/sources/response/cgi_handler.cpp
+++ b/sources/response/cgi_handler.cpp
@@ -136,7 +136,7 @@ void CgiHandler::DetachChildCgi() {
 
 	execve(argv[0], argv, env_list_);
 	std::perror("execve : ");
-	exit(0);
+	exit(1);
 }
 
 void CgiHandler::SetupAndAddEvent(KqueueHandler &kq_handler, Udata *user_data,

--- a/sources/response/cgi_handler.cpp
+++ b/sources/response/cgi_handler.cpp
@@ -160,6 +160,7 @@ void CgiHandler::SetupAndAddEvent(KqueueHandler &kq_handler, Udata *user_data,
 	if (pid == 0) {
 		DetachChildCgi();
 	} else {
+		kq_handler.AddProcExitEvent(pid);
 		SetupParentCgi();
 	}
 }

--- a/sources/response/cgi_handler.cpp
+++ b/sources/response/cgi_handler.cpp
@@ -36,7 +36,7 @@ void CgiHandler::ParseEnviron() {
 }
 
 void CgiHandler::ConvertEnvToCharSequence() {
-	env_list_ = new char *[cgi_envs_.size()];  // new 실패시 예외 처리
+	env_list_ = new char *[cgi_envs_.size() + 1];  // new 실패시 예외 처리
 
 	size_t i = 0;
 	for (std::map<std::string, std::string>::const_iterator it =


### PR DESCRIPTION
- kqueue에 fork한 자식프로세스 pid의 exit 이벤트를 모니터링할 수 있게 등록
- 이벤트가 발생하면 waitpid WNOHANG 옵션을 이용해 논블럭킹으로 자식 프로세스의 종료 상태를 회수함