### PR TITLE
fix: client_max_body_size 옵션 ningx와 일치하게 수정

### DIFF
--- a/sources/config/location_info.cpp
+++ b/sources/config/location_info.cpp
@@ -3,7 +3,7 @@
 #include <sstream>
 
 LocationInfo::LocationInfo()
-	: client_max_body_size_(1000000),
+	: client_max_body_size_(-1),
 	  autoindex_(false),
 	  path_(""),
 	  root_(""),

--- a/sources/config/server_info.cpp
+++ b/sources/config/server_info.cpp
@@ -198,8 +198,7 @@ std::vector<std::string> ServerInfo::GetAllowedMethod() const {
 size_t ServerInfo::GetClientMaxBodySize() const {
 	if ((location_index_ == -1) || (locations_[location_index_].GetClientMaxBodySize() == -1))
 		return this->client_max_body_size_;
-	else 
-		return this->locations_[location_index_].GetClientMaxBodySize();
+	return this->locations_[location_index_].GetClientMaxBodySize();
 }
 
 std::string ServerInfo::ToString() const {

--- a/sources/config/server_info.cpp
+++ b/sources/config/server_info.cpp
@@ -196,12 +196,10 @@ std::vector<std::string> ServerInfo::GetAllowedMethod() const {
 }
 
 size_t ServerInfo::GetClientMaxBodySize() const {
-	int temp;
-	if (location_index_ == -1)
-		temp = client_max_body_size_;
-	else
-		temp = this->locations_[location_index_].GetClientMaxBodySize();
-	return temp;
+	if ((location_index_ == -1) || (locations_[location_index_].GetClientMaxBodySize() == -1))
+		return this->client_max_body_size_;
+	else 
+		return this->locations_[location_index_].GetClientMaxBodySize();
 }
 
 std::string ServerInfo::ToString() const {


### PR DESCRIPTION
location 의 변수는 직접 변경 되지 않지만 
ServerInfo 블락에서 GetClientMaxBodySize()함수 호출시 nginx 규칙에 맞게 잘 리턴 됩니다. 