### PR TITLE
fix: kevent seg fault 해결

### DIFF
--- a/includes/core/kqueue_handler.hpp
+++ b/includes/core/kqueue_handler.hpp
@@ -14,8 +14,6 @@ class KqueueHandler {
 	void AddWriteEvent(uintptr_t ident, void *udata);
 	void AddWriteLogEvent(uintptr_t ident, void *udata);
 	void AddProcExitEvent(uintptr_t ident);
-	void DeleteReadEvent(uintptr_t ident);
-	void DeleteWriteEvent(uintptr_t ident);
 	void DeleteEvent(const struct kevent &event);
 
 	std::vector<struct kevent> MonitorEvent();

--- a/sources/core/event_executor.cpp
+++ b/sources/core/event_executor.cpp
@@ -334,6 +334,7 @@ void EventExecutor::SendResponse(KqueueHandler &kqueue_handler, struct kevent &e
 			kqueue_handler.DeleteEvent(event); // DELETE SEND_RESPONSE
 			user_data->ChangeState(Udata::READ_FILE);
 			kqueue_handler.AddReadEvent(error_page_fd, user_data); // ADD READ_FILE
+			return;
 		}
 	}
 	if (method == "HEAD") {
@@ -358,7 +359,7 @@ void EventExecutor::SendResponse(KqueueHandler &kqueue_handler, struct kevent &e
 			delete client_socket;
 			return;
 		}
-		kqueue_handler.DeleteEvent(event); // DELETE SEND_RESPONSE
+		kqueue_handler.DeleteEvent(event);
 		user_data->Reset();    // reset user data (state = RECV_REQUEST)
 		kqueue_handler.AddReadEvent(fd, user_data);    // RECV_REQUEST
 		request.total_length_ = 0;

--- a/sources/core/kqueue_handler.cpp
+++ b/sources/core/kqueue_handler.cpp
@@ -42,15 +42,9 @@ void KqueueHandler::AddProcExitEvent(uintptr_t ident) {
 }
 
 void KqueueHandler::DeleteEvent(const struct kevent &event) {
-	CollectEvents(event.ident, event.filter, EV_DELETE, 0, 0, NULL);
-}
-
-void KqueueHandler::DeleteReadEvent(uintptr_t ident) {
-	CollectEvents(ident, EVFILT_READ, EV_DELETE, 0, 0, 0);
-}
-
-void KqueueHandler::DeleteWriteEvent(uintptr_t ident) {
-	CollectEvents(ident, EVFILT_WRITE, EV_DELETE, 0, 0, 0);
+	struct kevent set_event = {};
+	EV_SET(&set_event, event.ident, event.filter, EV_DELETE, 0, 0, NULL);
+	kevent(kq_, &set_event, 1, NULL, 0, NULL);
 }
 
 void KqueueHandler::CollectEvents(uintptr_t ident, int16_t filter,

--- a/sources/core/webserv.cpp
+++ b/sources/core/webserv.cpp
@@ -131,7 +131,8 @@ void Webserv::HandleException(const HttpException &e, struct kevent &event) {
 	// std::cerr << user_data->request_message_ << C_RESET << std::endl;
 	kq_handler_.AddWriteLogEvent(Webserv::error_log_fd_, new Logger(e.what())); // make error logs
 
-//	kq_handler_.DeleteReadEvent(event.ident);
+	// kq_handler_.DeleteReadEvent(event.ident);
+	kq_handler_.DeleteEvent(event);
 //	user_data->Reset();
 	ResponseMessage response_message(e.GetStatusCode(), e.GetReasonPhrase()); // make response message
 	if (user_data->request_message_.ShouldClose())


### PR DESCRIPTION
## 문제
- SendResponse를 하기 전에 소켓에 대해 적절한 DeleteReadEvent를 하지 않아 seg fault가 났었음
- DeleteReadEvent 를 제대로 하지 않아 소켓에 대한 Read, Write 이벤트가 동시에 발생하게 되었고
- 동시에 발생한 이벤트를 for문을 돌며 처리하는 도중 이전 이벤트에서 udata의 값을 바꾸게 되면
- 다음에 처리해야 했을 이벤트의 원래 상태가 업데이트가 돼서 문제가 생겼었음

## 해결
- 애초에 소켓에대한 READ, WRITE 이벤트가 동시에 발생하게 하면 안 됨
- 소켓에 대한 AddWriteEvent를 하기 전에 무 조 건 소켓에 대한 DeleteReadEvent가 이뤄져야 함
- 대신 이러면 HandleRequestResult에서 DeleteEvent가 중복되어 추가 되는 경우가 생겼음
- DeleteEvent의 경우 중복 되어 들어가면 kevent가 제대로 처리하지 못하는 경우가 발생
- 이를 해결하기 위해 DeleteEvent는 CollectEvents로 벡터에 모아뒀다가 나중에 한 번에 추가 하는 게 아니라, 한 번에 하나씩 kevent로 바로 등록할 수 있게 해줬음